### PR TITLE
nav to list on click

### DIFF
--- a/app/assets/javascripts/views/stacks/show.js.coffee
+++ b/app/assets/javascripts/views/stacks/show.js.coffee
@@ -63,7 +63,7 @@ class listApp.Views.ListItemShow extends Backbone.View
 
   nav: (e) ->
     e.preventDefault()
-    path = $(e.target).attr('href')
+    path = e.currentTarget.href
     listApp.router.navigate(path, {trigger: true}) if path
 
   deleteList: (e) ->


### PR DESCRIPTION
some clicks were not finding the correct href (and hence, not navigating on click) but this is corrected by referencing `currentTarget` instead.